### PR TITLE
Investigate missing buy button on pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2569,6 +2569,79 @@ button:hover {
     border-left: 4px solid #6c757d;
 }
 
+/* Error Parts Section */
+.error-parts {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 1px solid #dee2e6;
+}
+
+.error-parts h5 {
+    margin: 0 0 1rem 0;
+    color: #495057;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.error-parts .parts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.error-parts .part-item {
+    margin: 0;
+    padding: 0.75rem;
+    background: white;
+    border-radius: 6px;
+    border: 1px solid #dee2e6;
+}
+
+.error-parts .part-info h6 {
+    margin: 0 0 0.25rem 0;
+    font-size: 0.95rem;
+    color: #212529;
+}
+
+.error-parts .part-number {
+    margin: 0 0 0.25rem 0;
+    font-size: 0.85rem;
+    color: #6c757d;
+}
+
+.error-parts .part-description {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.85rem;
+    color: #495057;
+}
+
+.error-parts .part-price {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.error-parts .price {
+    font-weight: 600;
+    color: #28a745;
+    font-size: 1rem;
+}
+
+.error-parts .part-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.error-parts .btn-sm {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+}
+
 .part-info h5 {
     margin: 0 0 0.5rem 0;
     color: #333;


### PR DESCRIPTION
Add 'Buy' buttons to parts on the parts page and integrate required parts with buy/compare buttons into the error codes display.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbed1a12-dd02-4db2-abcd-971ff3cc587d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbed1a12-dd02-4db2-abcd-971ff3cc587d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

